### PR TITLE
Removed end line '.' from `Code Style` page

### DIFF
--- a/src/routes/docs/contributing/code-style/+page.md
+++ b/src/routes/docs/contributing/code-style/+page.md
@@ -45,19 +45,19 @@ To make the codebase consistent and easy to understand, we require you to follow
 
 ### 3. Code readability and clarity
 
-- Do not use curly brackets for single line `if`, `for` and `foreach` statements.'
+- Do not use curly brackets for single line `if`, `for` and `foreach` statements
 - Do not use `#region` directives
 - Align `while();` on the same line of curly bracket of `do..while`
 - Use the prefixes `Is`, `Has`, `Have`, `Any`, `Can` or similar keywords for boolean names and method names if
-  applicable.
-- Do not use `Enum` or `Flag(s)` suffixes/prefixes for Enum names.
+  applicable
+- Do not use `Enum` or `Flag(s)` suffixes/prefixes for Enum names
 - Align curly brackets on new lines
 - Fields, properties, methods and constructors must be separated by one line except for property backing fields that are
   not separated by any amount of lines
 - Do not manually invoke event handling functions or commands
 - Do not use `public` modifiers in interface's properties and functions
 - Define constant types in `Constants` class following its structure
-- Mark classes as `abstract` or `sealed` if applicable.
+- Mark classes as `abstract` or `sealed` if applicable
 - Interfaces must be documented
 - Always create new `EventArgs` classes for event arguments
 - Add letter suffix to number values: `0.1d`, `100000000000L`, `1.1f`


### PR DESCRIPTION
## Description
Only four lines of `Code Style` ended with a '.', I removed them

## Motivation and Context
I think it looks better if all the lines have the same style

## Screenshots (if appropriate):
Before:
![1](https://user-images.githubusercontent.com/102259289/212533414-0a013c9d-05f8-49ee-809c-39040b0dc745.png)
